### PR TITLE
Update com.teslacoilsw.launcher.json

### DIFF
--- a/rules/apps/com.teslacoilsw.launcher.json
+++ b/rules/apps/com.teslacoilsw.launcher.json
@@ -1,9 +1,18 @@
 {
   "package": "com.teslacoilsw.launcher",
-  "recommended": false,
-  "verified": true,
+  "recommended": true,
+  "verified": false,
   "authors": [
     "ariaoftime"
   ],
-  "observers": []
+  "observers": [
+    {
+      "call_media_scan": false,
+      "add_to_downloads": false,
+      "source": "data/com.teslacoilsw.launcher/backup",
+      "target": "Documents/NovaLauncher",
+      "description": "app_backup",
+      "allow_child": false
+    }
+  ]
 }


### PR DESCRIPTION
将使用nova备份到储存设备时产生的不规范应用备份重定向到Documents文件夹中。