### PR TITLE
删除nova launcher的认证

### DIFF
--- a/rules/verified_apps.json
+++ b/rules/verified_apps.json
@@ -540,9 +540,6 @@
     "package_name": "com.teremok.influence"
   },
   {
-    "package_name": "com.teslacoilsw.launcher"
-  },
-  {
     "package_name": "com.teslacoilsw.launcherclientproxy"
   },
   {


### PR DESCRIPTION
删除nova launcher的认证，因为其备份时使用了非标准文件夹。