### PR TITLE
add cloudmusic downloaded podcast redirecting rule

### DIFF
--- a/rules/apps/com.netease.cloudmusic.json
+++ b/rules/apps/com.netease.cloudmusic.json
@@ -20,6 +20,14 @@
       "allow_child": false
     },
     {
+      "call_media_scan": true,
+      "add_to_downloads": false,
+      "source": "netease/cloudmusic/dj",
+      "target": "Podcasts/NetEase",
+      "description": "downloaded_podcast",
+      "allow_child": false
+    },
+    {
       "mask": ".*(?<!\\.tmp)$",
       "call_media_scan": true,
       "add_to_downloads": false,


### PR DESCRIPTION
把网易云音乐下载的电台节目放到根目录Podcasts文件夹内.