### PR TITLE
添加 西瓜课表(com.weilylab.xhuschedule) 认证应用

### DIFF
--- a/rules/apps/com.weilylab.xhuschedule.json
+++ b/rules/apps/com.weilylab.xhuschedule.json
@@ -1,13 +1,9 @@
 {
     "package": "com.weilylab.xhuschedule",
     "recommended": false,
-    "authors": [
-      "Mystery0"
-    ],
-    "observers": [
-    ],
+    "verified": true,
+    "authors": ["Mystery0"],
     "description": {
         "zh_CN": "<b>应用无在/sdcard创建任何文件夹和任何文件的行为，所有产生的数据存储按照官方规范存放！</b>"
-      },
-    "verified": true
-  }
+    }
+}

--- a/rules/apps/com.weilylab.xhuschedule.json
+++ b/rules/apps/com.weilylab.xhuschedule.json
@@ -1,0 +1,13 @@
+{
+    "package": "com.weilylab.xhuschedule",
+    "recommended": false,
+    "authors": [
+      "Mystery0"
+    ],
+    "observers": [
+    ],
+    "description": {
+        "zh_CN": "<b>应用无在/sdcard创建任何文件夹和任何文件的行为，所有产生的数据存储按照官方规范存放！</b>"
+      },
+    "verified": true
+  }


### PR DESCRIPTION
此应用无任何在非标准目录创建文件夹和文件的行为