### PR TITLE
停止微信自动写入test_writable时产生的通知

### DIFF
--- a/rules/apps/com.tencent.mm.json
+++ b/rules/apps/com.tencent.mm.json
@@ -40,7 +40,7 @@
       "target": "Download/WeChat",
       "description": "saved_files",
       "allow_child": false,
-      "mask": "^(?!com\\.tencent\\.xin\\.emoticon).*$",
+      "mask": "(^(?!com\\.tencent\\.xin\\.emoticon|test_writable).*$)|(^test_writable.+)",
       "id": "saved_files_0"
     }
   ],


### PR DESCRIPTION
微信7.0更新后会尝试往其download目录写入test_writable文件。所以修改了一下有关的正则表达式。让StorageRedirect不重定向此文件，同时可以避免写入这个文件时产生通知。