### PR TITLE
fix qq input send meme in wechat

### DIFF
--- a/rules/apps/com.tencent.mm.json
+++ b/rules/apps/com.tencent.mm.json
@@ -84,6 +84,14 @@
       "paths": [
         "WechatXposed"
       ]
+    },
+    {
+      "id": "qqinput",
+      "source_package": "com.tencent.mm",
+      "target_package": "com.tencent.qqpinyin",
+      "paths": [
+        "tencent"
+      ]
     }
   ],
   "simple_mounts_descriptions": {
@@ -101,6 +109,11 @@
       "zh_CN": "修复 <b>WeXposed（微X模块）</b> 失效",
       "zh": "修復 <b>WeXposed</b> 失效",
       "en": "Fix <b>WeXposed</b> not work"
+    },
+    "qqinput": {
+      "zh_CN": "修复 <b>QQ 输入法</b> 发表情",
+      "zh": "修復 <b>QQ 輸入法</b> 發表情",
+      "en": "Fix <b>QQ Input</b> send memes"
     }
   }
 }


### PR DESCRIPTION
表情文件存储在 /storage/emulated/0/Tencent/QQInput/Temp/ 目录中
QQ 输入法填写表情路径在输入框，微信根据路径读图然后展示出来