### PR TITLE
修复 星空视频壁纸设置壁纸黑屏

### DIFF
--- a/rules/apps/yyc.xk.core.json
+++ b/rules/apps/yyc.xk.core.json
@@ -1,8 +1,9 @@
 {
   "package": "yyc.xk.core",
   "recommended": true,
-  "verified": true,
+  "verified": false,
   "authors": [
-    "ChemCodex"
+    "ChemCodex",
+    "Hexer"
   ]
 }

--- a/rules/apps/yyc.xk.core.json
+++ b/rules/apps/yyc.xk.core.json
@@ -1,6 +1,6 @@
 {
   "package": "yyc.xk.core",
-  "recommended": false,
+  "recommended": true,
   "verified": true,
   "authors": [
     "ChemCodex"

--- a/rules/apps/yyc.xk.json
+++ b/rules/apps/yyc.xk.json
@@ -3,7 +3,8 @@
   "recommended": true,
   "verified": false,
   "authors": [
-    "SeanChengN"
+    "SeanChengN",
+    "Hexer"
   ],
   "observers": [
     {
@@ -12,5 +13,22 @@
       "target": "Movies/StarryVideoWallpapers",
       "id": "saved_videos_0"
     }
-  ]
+  ],
+  "simple_mounts": [
+    {
+      "id": "video",
+      "source_package": "yyc.xk",
+      "target_package": "yyc.xk.core",
+      "paths": [
+        "星空视频壁纸"
+      ]
+    }
+  ],
+  "simple_mounts_descriptions": {
+    "video": {
+      "zh_CN": "修复设置壁纸时黑屏，无法设置视频壁纸",
+      "zh": "修復設置壁紙時黑屏，無法設置視頻壁紙",
+      "en": "Fix black screen when setting wallpaper, unable to set video wallpaper"
+    }
+  }
 }


### PR DESCRIPTION
星空视频壁纸 这个App是一款可以把视频设置为壁纸的App，
开启重定向后，星空视频壁纸引擎找不到根目录下的 “星空视频壁纸”文件夹，因此无法播放视频，
添加共享文件夹可以解决这个问题