### PR TITLE
update rule

### DIFF
--- a/rules/apps/bingdic.android.activity.json
+++ b/rules/apps/bingdic.android.activity.json
@@ -1,10 +1,8 @@
 {
   "package": "bingdic.android.activity",
-  "recommended": false,
-  "verified": true,
-  "description": {
-    "zh_CN": "开启后请谨慎清理应用缓存，否则可能会造成离线词典丢失！"
-  },
+  "recommended": true,
+  "verified": false,
+ 
   "authors": [
     "zhxhwyzh14"
   ]

--- a/rules/apps/com.microsoft.launcher.json
+++ b/rules/apps/com.microsoft.launcher.json
@@ -3,6 +3,17 @@
   "recommended": true,
   "verified": false,
   "authors": [
-    "OpportunityLiu"
+    "OpportunityLiu",
+    "sakuyamaij"
+  ],
+  "observers": [
+    {
+      "call_media_scan": false,
+      "add_to_downloads": false,
+      "source": "Arrow/backup",
+      "target": "Documents/MicrosoftLauncher",
+      "description": "app_backup",
+      "allow_child": false
+    }
   ]
 }

--- a/rules/apps/org.telegram.messenger.json
+++ b/rules/apps/org.telegram.messenger.json
@@ -4,7 +4,45 @@
   "verified": false,
   "authors": [
     "coderfox",
-    "nickyc4"
+    "nickyc4",
+    "zhxhwyzh14"
   ],
-  "observers": []
+  "observers": [
+    {
+      "call_media_scan": true,
+      "add_to_downloads": false,
+      "source": "Telegram/Telegram Video",
+      "target": "Movies/Telegram",
+      "description": "downloaded_videos",
+      "allow_child": false,
+      "id": "downloaded_video_0"
+    },
+    {
+      "call_media_scan": false,
+      "add_to_downloads": false,
+      "source": "Telegram/Telegram Documents",
+      "target": "Documents/Telegram",
+      "description": "saved_files",
+      "allow_child": false,
+      "id": "downloaded_files_0"
+    },
+    {
+      "call_media_scan": true,
+      "add_to_downloads": false,
+      "source": "Telegram/Telegram Audio",
+      "target": "Music/Telegram",
+      "description": "downloaded_music",
+      "allow_child": false,
+      "id": "downloaded_audio_0"
+    },
+     {
+      "call_media_scan": true,
+      "add_to_downloads": false,
+      "source": "Telegram/Telegram Images",
+      "target": "Pictures/Telegram",
+      "description": "downloaded_pictures",
+      "allow_child": false,
+      "id": "downloaded_pictures_0"
+    }
+  ]
 }


### PR DESCRIPTION
必应词典现在已经能产生垃圾文件夹，包括Bingfm和bingdict两个。
微软桌面参考sakuyamaij ，重定向备份文件到标准文件夹
telegram是重定向四种资源文件到标准文件夹。