### PR TITLE
update rules

### DIFF
--- a/rules/apps/bingdic.android.activity.json
+++ b/rules/apps/bingdic.android.activity.json
@@ -1,10 +1,8 @@
 {
   "package": "bingdic.android.activity",
-  "recommended": false,
-  "verified": true,
-  "description": {
-    "zh_CN": "开启后请谨慎清理应用缓存，否则可能会造成离线词典丢失！"
-  },
+  "recommended": true,
+  "verified": false,
+ 
   "authors": [
     "zhxhwyzh14"
   ]

--- a/rules/apps/com.eg.android.AlipayGphone.json
+++ b/rules/apps/com.eg.android.AlipayGphone.json
@@ -5,9 +5,6 @@
   "authors": [
     "DEVELOPER"
   ]
-  
-  
-  
     "simple_mounts": [
     {
       "id": "colorqq",
@@ -25,6 +22,4 @@
       "en": "Fix <b>ColorQQ</b> not work"
     }
   }
-  
-  
 }

--- a/rules/apps/com.eg.android.AlipayGphone.json
+++ b/rules/apps/com.eg.android.AlipayGphone.json
@@ -3,7 +3,8 @@
   "recommended": true,
   "verified": false,
   "authors": [
-    "DEVELOPER"
+    "DEVELOPER",
+    "zhxhwyzh14"
   ],
     "simple_mounts": [
     {
@@ -18,9 +19,9 @@
   ],
   "simple_mounts_descriptions": {
     "slzy": {
-      "zh_CN": "修复 <b>ColorQQ</b> 失效",
-      "zh": "修復 <b>ColorQQ</b> 失效",
-      "en": "Fix <b>ColorQQ</b> not work"
+      "zh_CN": "修复 <b>森林&庄园</b> 失效",
+      "zh": "修復 <b>森林&庄园</b> 失效",
+      "en": "Fix <b>森林&庄园</b> not work"
     }
   }
 }

--- a/rules/apps/com.eg.android.AlipayGphone.json
+++ b/rules/apps/com.eg.android.AlipayGphone.json
@@ -15,7 +15,7 @@
         "backups"
       ]
     }
-  ],
+  ]
   "simple_mounts_descriptions": {
     "slzy": {
       "zh_CN": "修复 <b>ColorQQ</b> 失效",

--- a/rules/apps/com.eg.android.AlipayGphone.json
+++ b/rules/apps/com.eg.android.AlipayGphone.json
@@ -11,7 +11,7 @@
       "source_package": "z.houbin.em.energy",
       "target_package": "com.eg.android.AlipayGphone",
       "paths": [
-        "em"
+        "em",
         "backups"
       ]
     }

--- a/rules/apps/com.eg.android.AlipayGphone.json
+++ b/rules/apps/com.eg.android.AlipayGphone.json
@@ -7,8 +7,7 @@
   ]
     "simple_mounts": [
     {
-      "id": "slzy
-  ",
+      "id": "slzy",
       "source_package": "z.houbin.em.energy",
       "target_package": "com.eg.android.AlipayGphone",
       "paths": [

--- a/rules/apps/com.eg.android.AlipayGphone.json
+++ b/rules/apps/com.eg.android.AlipayGphone.json
@@ -4,7 +4,7 @@
   "verified": false,
   "authors": [
     "DEVELOPER"
-  ]
+  ],
     "simple_mounts": [
     {
       "id": "slzy",

--- a/rules/apps/com.eg.android.AlipayGphone.json
+++ b/rules/apps/com.eg.android.AlipayGphone.json
@@ -7,16 +7,18 @@
   ]
     "simple_mounts": [
     {
-      "id": "colorqq",
+      "id": "slzy
+  ",
       "source_package": "z.houbin.em.energy",
       "target_package": "com.eg.android.AlipayGphone",
       "paths": [
         "em"
+        "backups"
       ]
     }
   ],
   "simple_mounts_descriptions": {
-    "colorqq": {
+    "slzy": {
       "zh_CN": "修复 <b>ColorQQ</b> 失效",
       "zh": "修復 <b>ColorQQ</b> 失效",
       "en": "Fix <b>ColorQQ</b> not work"

--- a/rules/apps/com.eg.android.AlipayGphone.json
+++ b/rules/apps/com.eg.android.AlipayGphone.json
@@ -15,7 +15,7 @@
         "backups"
       ]
     }
-  ]
+  ],
   "simple_mounts_descriptions": {
     "slzy": {
       "zh_CN": "修复 <b>ColorQQ</b> 失效",

--- a/rules/apps/com.eg.android.AlipayGphone.json
+++ b/rules/apps/com.eg.android.AlipayGphone.json
@@ -5,4 +5,26 @@
   "authors": [
     "DEVELOPER"
   ]
+  
+  
+  
+    "simple_mounts": [
+    {
+      "id": "colorqq",
+      "source_package": "z.houbin.em.energy",
+      "target_package": "com.eg.android.AlipayGphone",
+      "paths": [
+        "em"
+      ]
+    }
+  ],
+  "simple_mounts_descriptions": {
+    "colorqq": {
+      "zh_CN": "修复 <b>ColorQQ</b> 失效",
+      "zh": "修復 <b>ColorQQ</b> 失效",
+      "en": "Fix <b>ColorQQ</b> not work"
+    }
+  }
+  
+  
 }

--- a/rules/apps/com.microsoft.launcher.json
+++ b/rules/apps/com.microsoft.launcher.json
@@ -3,6 +3,17 @@
   "recommended": true,
   "verified": false,
   "authors": [
-    "OpportunityLiu"
+    "OpportunityLiu",
+    "sakuyamaij"
+  ],
+  "observers": [
+    {
+      "call_media_scan": false,
+      "add_to_downloads": false,
+      "source": "Arrow/backup",
+      "target": "Documents/MicrosoftLauncher",
+      "description": "app_backup",
+      "allow_child": false
+    }
   ]
 }

--- a/rules/apps/org.telegram.messenger.json
+++ b/rules/apps/org.telegram.messenger.json
@@ -4,7 +4,45 @@
   "verified": false,
   "authors": [
     "coderfox",
-    "nickyc4"
+    "nickyc4",
+    "zhxhwyzh14"
   ],
-  "observers": []
+  "observers": [
+    {
+      "call_media_scan": true,
+      "add_to_downloads": false,
+      "source": "Telegram/Telegram Video",
+      "target": "Movies/Telegram",
+      "description": "downloaded_videos",
+      "allow_child": false,
+      "id": "downloaded_video_0"
+    },
+    {
+      "call_media_scan": false,
+      "add_to_downloads": false,
+      "source": "Telegram/Telegram Documents",
+      "target": "Documents/Telegram",
+      "description": "saved_files",
+      "allow_child": false,
+      "id": "downloaded_files_0"
+    },
+    {
+      "call_media_scan": true,
+      "add_to_downloads": false,
+      "source": "Telegram/Telegram Audio",
+      "target": "Music/Telegram",
+      "description": "downloaded_music",
+      "allow_child": false,
+      "id": "downloaded_audio_0"
+    },
+     {
+      "call_media_scan": true,
+      "add_to_downloads": false,
+      "source": "Telegram/Telegram Images",
+      "target": "Pictures/Telegram",
+      "description": "downloaded_pictures",
+      "allow_child": false,
+      "id": "downloaded_pictures_0"
+    }
+  ]
 }

--- a/rules/apps/z.houbin.em.energy.json
+++ b/rules/apps/z.houbin.em.energy.json
@@ -15,7 +15,7 @@
         "backups"
       ]
     }
-  ],
+  ]
   "simple_mounts_descriptions": {
     "slzy": {
       "zh_CN": "修复 <b>ColorQQ</b> 失效",

--- a/rules/apps/z.houbin.em.energy.json
+++ b/rules/apps/z.houbin.em.energy.json
@@ -5,7 +5,7 @@
   "authors": [
     "zhxhwyzh14"
   ]
-  "simple_mounts": [
+  "simple_mounts":[
     {
       "id": "slzy",
       "source_package": "z.houbin.em.energy",

--- a/rules/apps/z.houbin.em.energy.json
+++ b/rules/apps/z.houbin.em.energy.json
@@ -11,7 +11,7 @@
       "source_package": "z.houbin.em.energy",
       "target_package": "com.eg.android.AlipayGphone",
       "paths": [
-        "em"
+        "em",
         "backups"
       ]
     }

--- a/rules/apps/z.houbin.em.energy.json
+++ b/rules/apps/z.houbin.em.energy.json
@@ -15,7 +15,7 @@
         "backups"
       ]
     }
-  ]
+  ],
   "simple_mounts_descriptions": {
     "slzy": {
       "zh_CN": "修复 <b>ColorQQ</b> 失效",

--- a/rules/apps/z.houbin.em.energy.json
+++ b/rules/apps/z.houbin.em.energy.json
@@ -1,0 +1,8 @@
+{
+  "package": "z.houbin.em.energy",
+  "recommended": true,
+  "verified": false,
+  "authors": [
+    "zhxhwyzh14"
+  ]
+}

--- a/rules/apps/z.houbin.em.energy.json
+++ b/rules/apps/z.houbin.em.energy.json
@@ -18,9 +18,9 @@
   ],
   "simple_mounts_descriptions": {
     "slzy": {
-      "zh_CN": "修复 <b>ColorQQ</b> 失效",
-      "zh": "修復 <b>ColorQQ</b> 失效",
-      "en": "Fix <b>ColorQQ</b> not work"
+      "zh_CN": "修复 <b>森林&庄园</b> 失效",
+      "zh": "修復 <b>森林&庄园</b> 失效",
+      "en": "Fix <b>森林&庄园</b> not work"
     }
   }
 }

--- a/rules/apps/z.houbin.em.energy.json
+++ b/rules/apps/z.houbin.em.energy.json
@@ -4,7 +4,7 @@
   "verified": false,
   "authors": [
     "zhxhwyzh14"
-  ]
+  ],
   "simple_mounts":[
     {
       "id": "slzy",

--- a/rules/apps/z.houbin.em.energy.json
+++ b/rules/apps/z.houbin.em.energy.json
@@ -5,4 +5,22 @@
   "authors": [
     "zhxhwyzh14"
   ]
+  "simple_mounts": [
+    {
+      "id": "slzy",
+      "source_package": "z.houbin.em.energy",
+      "target_package": "com.eg.android.AlipayGphone",
+      "paths": [
+        "em"
+        "backups"
+      ]
+    }
+  ],
+  "simple_mounts_descriptions": {
+    "slzy": {
+      "zh_CN": "修复 <b>ColorQQ</b> 失效",
+      "zh": "修復 <b>ColorQQ</b> 失效",
+      "en": "Fix <b>ColorQQ</b> not work"
+    }
+  }
 }

--- a/rules/verified_apps.json
+++ b/rules/verified_apps.json
@@ -15,9 +15,6 @@
     "package_name": "batterywidget.mikuapp.mikulaboplut"
   },
   {
-    "package_name": "bingdic.android.activity"
-  },
-  {
     "package_name": "bos.consoar.countdown"
   },
   {


### PR DESCRIPTION
必应词典现在已经能产生垃圾文件夹，包括Bingfm和bingdict两个。
微软桌面参考sakuyamaij ，重定向备份文件到标准文件夹
telegram是重定向四种资源文件到标准文件夹。
取消 必应词典的认证。