### PR TITLE
update com.qianyan.eudic

### DIFF
--- a/rules/apps/com.qianyan.eudic.json
+++ b/rules/apps/com.qianyan.eudic.json
@@ -2,9 +2,9 @@
   "package": "com.qianyan.eudic",
   "recommended": true,
   "verified": false,
- "authors": [
-   "annycyb"
- ],
+  "authors": [
+    "annycyb"
+  ],
   "observers": [
     { 
       "source": "eudb_en",
@@ -16,4 +16,5 @@
       "allow_child": false,
       "allow_temp": false
     }
+  ]
 }

--- a/rules/apps/com.qianyan.eudic.json
+++ b/rules/apps/com.qianyan.eudic.json
@@ -2,7 +2,18 @@
   "package": "com.qianyan.eudic",
   "recommended": true,
   "verified": false,
-  "authors": [
-    "xhn16729"
-  ]
+ "authors": [
+   "annycyb"
+ ],
+  "observers": [
+    { 
+      "source": "eudb_en",
+      "target": "Documents/eudb_en",
+      "description": "app backup",
+      "call_media_scan": false,
+      "add_to_downloads": false,
+      "mask": ".+\.(eudb)$",
+      "allow_child": false,
+      "allow_temp": false
+    }
 }


### PR DESCRIPTION
Adding a synced folder to keep the dictionary after reinstalling.

#"mask": ".+.(eudb)$" is used for target the dictionary and deleting this string can keep the whole folder (which may contain part of trash).