### PR TITLE
Update com.rarlab.rar.json

### DIFF
--- a/rules/apps/com.rarlab.rar.json
+++ b/rules/apps/com.rarlab.rar.json
@@ -1,9 +1,20 @@
 {
   "package": "com.rarlab.rar",
-  "recommended": false,
-  "verified": true,
+  "recommended": true,
+  "verified": false,
   "authors": [
-    "fayeniko"
+    "fayeniko",
+    "zhxhwyzh14"
   ],
-  "observers": []
+  "observers": [
+    {
+      "call_media_scan": true,
+      "add_to_downloads": true,
+      "source": "rar",
+      "target": "Download/Winrar",
+      "description": "saved_files",
+      "allow_child": true,
+      "id": "saved_files_0"
+    }
+  ]
 }


### PR DESCRIPTION
RAR可以在根目录创建rar文件夹，不应该被认证。