### PR TITLE
修正两条已认证应用规则（产生非标准行为）

### DIFF
--- a/rules/apps/com.mxtech.videoplayer.ad.json
+++ b/rules/apps/com.mxtech.videoplayer.ad.json
@@ -1,7 +1,7 @@
 {
   "package": "com.mxtech.videoplayer.ad",
   "recommended": false,
-  "verified": true,
+  "verified": false,
   "authors": [
     "yiheng0",
     "tzwjkl"

--- a/rules/verified_apps.json
+++ b/rules/verified_apps.json
@@ -1398,9 +1398,6 @@
     "package_name": "com.musixmatch.android.lyrify"
   },
   {
-    "package_name": "com.mxtech.videoplayer.ad"
-  },
-  {
     "package_name": "com.myqsc.mobile3"
   },
   {
@@ -2881,9 +2878,6 @@
   },
   {
     "package_name": "vcoty.vainglory.go"
-  },
-  {
-    "package_name": "wangdaye.com.geometricweather"
   },
   {
     "package_name": "widget.dd.com.overdrop.pro"


### PR DESCRIPTION
删除`com.mxtech.videoplayer.ad` `wangdaye.com.geometricweather`，因为它们有**非标准行为**