### PR TITLE
Add andOTP (org.shadowice.floce.andotp)

### DIFF
--- a/rules/apps/org.shadowice.floce.andotp.json
+++ b/rules/apps/org.shadowice.floce.andotp.json
@@ -1,0 +1,8 @@
+{
+  "package": "org.shadowice.flocke.andotp",
+  "verified": true,
+  "authors": [
+    "outloudvi"
+  ],
+  "observers": []
+}


### PR DESCRIPTION
andOTP is a open-source 2FA authentication app on Android. [andOTP/andOTP](https://github.com/andOTP/andOTP)

This supercedes #2938.