### PR TITLE
Delete the verified status of com.miui.guardprovider

### DIFF
--- a/app_rule/verified_apps.json
+++ b/app_rule/verified_apps.json
@@ -1311,9 +1311,6 @@
         "package": "com.miui.daemon"
     },
     {
-        "package": "com.miui.guardprovider"
-    },
-    {
         "package": "com.miui.hybrid"
     },
     {


### PR DESCRIPTION
In view of the non-standard behavior of com.miui.guardprovider in MIUI 12, remove the verified status of the application